### PR TITLE
チャート削除機能の実装

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -15,6 +15,13 @@
     "import/no-extraneous-dependencies": "off",
     "label-has-associated-control": "off",
     "no-restricted-globals":"off",
-    "no-alert": "off"
+    "no-alert": "off",
+    "jsx-a11y/label-has-associated-control": [
+      "error",
+      {
+        "assert": "htmlFor",
+        "depth": 3
+      }
+    ]
   }
 }

--- a/src/app/api/myChart/reach/[...slug]/route.ts
+++ b/src/app/api/myChart/reach/[...slug]/route.ts
@@ -2,10 +2,24 @@
 
 import axios from "axios";
 
+const generateUrl = (id: number) => {
+  const encordId = encodeURIComponent(id);
+  const URL = `${process.env.LARAVEL_API_BASE_URL}/myChart/reach/${encordId}`;
+  return URL;
+}
+
 export async function PATCH(req: Request) {
   const reqData = await req.json();
-  const URL = `${process.env.LARAVEL_API_BASE_URL}/myChart/reach/${reqData.id}`;
+  const URL = generateUrl(reqData.id)
   const res = await axios.patch(URL, reqData);
   const data = await res.data;
   return Response.json(data);
+}
+
+export async function DELETE(req: Request) {
+  const reqData = await req.json();
+  const URL = generateUrl(reqData.id)
+  const res = await axios.delete(URL, {data: reqData});
+  const data = await res.data;
+  return Response.json(data)
 }

--- a/src/app/features/chartView/Reach.tsx
+++ b/src/app/features/chartView/Reach.tsx
@@ -2,10 +2,12 @@
 
 import { useSession } from "next-auth/react";
 import { useEffect, useRef, useState } from "react";
+import { Delete } from "@/components/elements/icons/Icons";
 import styles from "./styles/Reach.module.scss";
 import { JournalButton } from "../../components/elements/button/Button";
 import AuthDetail from "../../components/elements/authDetail/AuthDetail";
-import { ReachData, handleReachNameSubmit } from "./handlers/ReachHandler";
+import { ReachData, handleReachDeleteSubmit, handleReachNameSubmit } from "./handlers/ReachHandler";
+import { useAppDispatch } from "../../../store/hooks";
 
 
 
@@ -13,6 +15,9 @@ export default function Reach({ id, name, userEmail, userName, userImage }: Reac
 
   const { data: session } = useSession();
   const [reachName, setReachName] = useState<string>(name || '');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const dispatch = useAppDispatch();
+
   const authName = session?.user?.name
   const userData = {
     userName,
@@ -41,25 +46,38 @@ export default function Reach({ id, name, userEmail, userName, userImage }: Reac
     <div className={styles.container}>
       <div className={styles.reach}>
         {
-          userName === authName
+          userName === authName && id && userEmail
             ?
             <form
               className={styles.reach_title}
               ref={formRef}
-              onSubmit={(e) => handleReachNameSubmit({ e, reachData, setReachName })}
+              onSubmit={(e) => handleReachNameSubmit({ e, reachData, setReachName, setErrorMsg })}
             >
               <label
                 className={styles.reach_label}
-                htmlFor="reachName">
+                htmlFor="reachNameName">
                 REACH
-                <input
-                  id="reachName"
-                  type="text"
-                  name="reachName"
-                  defaultValue={reachName || ''}
-                  onBlur={() => { handleReachNameOnBlur() }}
-                />
               </label>
+              <input
+                id="reachNameName"
+                type="text"
+                name="reachName"
+                defaultValue={reachName || ''}
+                onBlur={() => { handleReachNameOnBlur() }}
+              />
+              {
+                errorMsg !== null
+                &&
+                <span
+                  style={{ color: 'red' }}
+                >
+                  {errorMsg}
+                </span>
+              }
+              <div className={styles.delete_container}>
+                <Delete deleteHandler={() => { handleReachDeleteSubmit({ id, userEmail, dispatch, setErrorMsg }) }} />
+              </div>
+
             </form>
             :
             <div className={styles.reach_title}>
@@ -75,8 +93,10 @@ export default function Reach({ id, name, userEmail, userName, userImage }: Reac
       {
 
         userName === authName
-          ? <JournalButton journal={name !== undefined ? name : ''} />
-          : <div className={styles.authDetail_container}>
+          ?
+          <JournalButton journal={name !== undefined ? name : ''} />
+          :
+          <div className={styles.authDetail_container}>
             <AuthDetail userData={userData} />
           </div>
       }

--- a/src/app/features/chartView/handlers/ReachHandler.ts
+++ b/src/app/features/chartView/handlers/ReachHandler.ts
@@ -1,6 +1,8 @@
 /* eslint-disable import/prefer-default-export */
 import axios from "axios";
 import { Dispatch, FormEvent, SetStateAction } from "react";
+import { deleteChart } from "../../../../store/slice/AuthChartsSlice";
+import { AppDispatch } from "../../../../store/store";
 
 export interface ReachData {
   id: number | undefined,
@@ -13,11 +15,20 @@ export interface ReachData {
 interface HandleReachNameSubmitProps {
   e: FormEvent<HTMLFormElement>,
   reachData: ReachData,
-  setReachName: Dispatch<SetStateAction<string>>
+  setReachName: Dispatch<SetStateAction<string>>,
+  setErrorMsg: Dispatch<SetStateAction<string | null>>
 }
 
-export const handleReachNameSubmit = async ({ e, reachData, setReachName }: HandleReachNameSubmitProps) => {
+interface HandleReachDeleteSubmitProps {
+  id: number,
+  userEmail: string,
+  dispatch: AppDispatch,
+  setErrorMsg: Dispatch<SetStateAction<string | null>>
+}
+
+export const handleReachNameSubmit = async ({ e, reachData, setReachName, setErrorMsg }: HandleReachNameSubmitProps) => {
   e.preventDefault();
+  setErrorMsg('');
   const form = new FormData(e.currentTarget);
   const editReachName = form.get('reachName');
   if (editReachName !== reachData.name) {
@@ -32,8 +43,30 @@ export const handleReachNameSubmit = async ({ e, reachData, setReachName }: Hand
       const data = await res.data;
       setReachName(data.reach.name);
     } catch (error) {
-      console.error('Failed to update reach name:', error);
+      setErrorMsg('Reachの変更に失敗しました。ï');
     }
+  }
+}
 
+export const handleReachDeleteSubmit = async ({ id, userEmail, dispatch, setErrorMsg }: HandleReachDeleteSubmitProps) => {
+  const result = confirm('チャートを削除しますか？登録されているSkill, Action, 振り返りすべてが削除されます。');
+  if (result) {
+    const finalResult = confirm('こちらのチャートを本当に削除します。');
+    setErrorMsg('');
+    if (finalResult) {
+      try {
+        const URL = `${process.env.NEXT_PUBLIC_BASE_URL}/api/myChart/reach/${id}`;
+        const reachDeletePayload = {
+          id,
+          userEmail
+        }
+        const res = await axios.delete(URL, { data: reachDeletePayload });
+        if (res.status === 200) {
+          dispatch(deleteChart(id));
+        }
+      } catch (error) {
+        setErrorMsg(`チャートの削除に失敗しました。`)
+      }
+    }
   }
 }

--- a/src/app/features/chartView/styles/Reach.module.scss
+++ b/src/app/features/chartView/styles/Reach.module.scss
@@ -16,18 +16,35 @@
       flex-direction: column;
       align-self: center;
       font-family: var(--font-en);
-    }
+      position: relative;
+      clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 
-    &_label {
-      font-weight: normal;
-      font-size: 1rem;
-      display: flex;
-      flex-direction: column;
+      &_label {
+        font-weight: normal;
+        font-size: 1rem;
+      }
 
       & input {
         font-family: var(--font-jp);
         font-weight: bold;
         font-size: 1.5rem;
+      }
+
+      & .delete_container {
+        width: 1rem;
+        aspect-ratio: 1/1;
+        display: flex;
+        position: absolute;
+        top: 0;
+        left: 4rem;
+        transform: translateY(-200%);
+        transition: all .1s $ease;
+      }
+
+      &:hover{
+        & .delete_container{
+          transform: translateY(0);
+        }
       }
     }
 

--- a/src/store/slice/AuthChartsSlice.ts
+++ b/src/store/slice/AuthChartsSlice.ts
@@ -63,6 +63,13 @@ const authChartsSlice = createSlice({
           actions: []
         }
       }
+    },
+    deleteChart(state, action) {
+      const id = action.payload;
+      const targetIndex = state.authChartDatas?.findIndex(chartData => chartData.id === id);
+      if (targetIndex !== -1 && typeof targetIndex === 'number') {
+        state.authChartDatas?.splice(targetIndex, 1);
+      }
     }
   },
   extraReducers: (builder) => {
@@ -83,4 +90,4 @@ const authChartsSlice = createSlice({
 })
 
 export default authChartsSlice.reducer;
-export const { addedSkill } = authChartsSlice.actions;
+export const { deleteChart, addedSkill } = authChartsSlice.actions;


### PR DESCRIPTION
リーチの削除機能を実装
1. リーチの削除===チャートの削除として実装
2. チャートをDBで削除したあとに表示が消えなかったため、AuthChartのreducerを追加
3. res.statusの確認してからreducerを呼び出して実行
4. errorの表示ステートの追加